### PR TITLE
[BUGFIX] Don't add flash message in CLI mode

### DIFF
--- a/Classes/Slot/AbstractResourceStorageSlot.php
+++ b/Classes/Slot/AbstractResourceStorageSlot.php
@@ -11,6 +11,7 @@ namespace Mehrwert\FalQuota\Slot;
 
 use InvalidArgumentException;
 use Mehrwert\FalQuota\Utility\QuotaUtility;
+use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Exception;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
@@ -277,7 +278,7 @@ abstract class AbstractResourceStorageSlot
      */
     protected function addMessageToFlashMessageQueue($message, $severity = FlashMessage::ERROR): void
     {
-        if (TYPO3_MODE !== 'BE') {
+        if (TYPO3_MODE !== 'BE' || Environment::isCli()) {
             return;
         }
         $flashMessage = GeneralUtility::makeInstance(


### PR DESCRIPTION
Without this fix, an error like this will be thrown if the extension is somehow triggered in CLI mode.

```
Uncaught TYPO3 Exception Argument 1 passed to TYPO3\CMS\Core\Session\Backend\DatabaseSessionBackend::update() must be of the type string, null given, called in /typo3/sysext/core/Classes/Authentication/AbstractUserAuthentication.php on line 1289
thrown in file /typo3/sysext/core/Classes/Session/Backend/DatabaseSessionBackend.php
in line 159
```