### PR TITLE
[BUGFIX] Resolve improper quota evaluation

### DIFF
--- a/Resources/Private/Language/de.locallang_resource_storage_messages.xlf
+++ b/Resources/Private/Language/de.locallang_resource_storage_messages.xlf
@@ -4,13 +4,13 @@
         <header/>
         <body>
             <trans-unit id="over_quota">
-                <target>Die Dateien in diesem Speicher belegen mehr Speicherplatz (%s MB) als die Quota (%s MB) erlaubt.</target>
+                <target>Die Dateien in diesem Speicher belegen mehr Speicherplatz (%s) als die Quota (%s) erlaubt.</target>
             </trans-unit>
             <trans-unit id="result_will_exceed_quota">
-                <target>Die Aktion würde in diesem Speicher mehr Speicherplatz belegen (%s MB) als die Quota (%s MB) erlaubt.</target>
+                <target>Die Aktion würde in diesem Speicher mehr Speicherplatz belegen (%s) als die Quota (%s) erlaubt.</target>
             </trans-unit>
             <trans-unit id="copy_folder_result_will_exceed_quota">
-                <target>Die Aktion würde im Ziel-Speicher mehr Speicherplatz belegen als die Quota (%s MB) erlaubt.</target>
+                <target>Die Aktion würde im Ziel-Speicher mehr Speicherplatz belegen als die Quota (%s) erlaubt.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/locallang_resource_storage_messages.xlf
+++ b/Resources/Private/Language/locallang_resource_storage_messages.xlf
@@ -4,13 +4,13 @@
         <header/>
         <body>
             <trans-unit id="over_quota">
-                <source>The files in this storage (%s MB) exceeded the Quota limit (%s MB).</source>
+                <source>The files in this storage (%s) exceeded the Quota limit (%s).</source>
             </trans-unit>
             <trans-unit id="result_will_exceed_quota">
-                <source>The desired action would use more space in this storage (%s MB) as the Quota limit (%s MB) permits.</source>
+                <source>The desired action would use more space in this storage (%s) as the Quota limit (%s) permits.</source>
             </trans-unit>
             <trans-unit id="copy_folder_result_will_exceed_quota">
-                <source>The desired action would use more space in the target storage as the Quota limit (%s MB) permits.</source>
+                <source>The desired action would use more space in the target storage as the Quota limit (%s) permits.</source>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
Due to several value type mixups (string vs. int vs. double) during
comparison of defined quotas with calculated estimates, the conditions
tended to not match causing false positive error messages to be
displayed.

Following changes are applied to counter this:

- Unify values (use bytes where applicable) to prevent conversion errors
- Convert to MB for FlashMessage output only
- Use '*_raw' values (the actual bytes) in conditions to prevent accidental
  comparison of number/string with bytes/megabytes

Signed-off-by: Tobias Stahn <Tobias.Stahn@mehrwert.de>