### PR TITLE
[TASK] Add `extension-key` to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,10 @@
     "psr-4": {
       "Mehrwert\\FalQuota\\": "Classes/"
     }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "fal_quota"
+    }
   }
 }


### PR DESCRIPTION
@see https://docs.typo3.org/m/typo3/reference-coreapi/9.5/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra

Resolves: #16