### PR TITLE
[BUGFIX] Use more specific CSS classes in module-icon.svg

### DIFF
--- a/Resources/Public/Images/Icons/module-icon.svg
+++ b/Resources/Public/Images/Icons/module-icon.svg
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <svg version="1.1" id="module-icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 64 64" style="enable-background:new 0 0 64 64;" xml:space="preserve">
+     viewBox="0 0 64 64" style="enable-background:new 0 0 64 64;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#4C7E3A;}
-	.st1{fill:#FFFFFF;}
-	.st2{fill:#FFFFFF;stroke:#4C7E3A;stroke-width:4;stroke-miterlimit:10;}
-	.st3{fill:#FFFFFF;stroke:#4C7E3A;stroke-width:2;stroke-miterlimit:10;}
+	.fal-quota-path__background{fill:#4C7E3A;}
+	.fal-quota-path__icon{fill:#FFFFFF;}
+	.fal-quota-path__icon{fill:#FFFFFF;stroke:#4C7E3A;stroke-width:4;stroke-miterlimit:10;}
+	.fal-quota-path__icon{fill:#FFFFFF;stroke:#4C7E3A;stroke-width:2;stroke-miterlimit:10;}
 </style>
-<path class="st0" d="M0,0h64v64H0V0z"/>
-<path class="st1" d="M36,30h10c0-0.7-0.1-1.4-0.3-2H36V30z M36,26h8.9c-0.4-0.8-1-1.4-1.6-2H36V26z M36,34h14.6
+    <path class="fal-quota-path__background" d="M0,0h64v64H0V0z"/>
+    <path class="fal-quota-path__icon" d="M36,30h10c0-0.7-0.1-1.4-0.3-2H36V30z M36,26h8.9c-0.4-0.8-1-1.4-1.6-2H36V26z M36,34h14.6
 	c-0.3-0.7-0.7-1.4-1.2-2H36V34z M34,40V21.9C32.1,20,29.6,19,27,19c-5.4,0-9.8,4.3-10,9.7c-3.5,1.6-5,5.8-3.4,9.3
 	c1.2,2.5,3.6,4,6.3,4h14L34,40L34,40z M36,38h14.7c0.2-0.6,0.3-1.3,0.3-2H36V38z M36,40v2h9c1.7,0,3.3-0.7,4.5-2H36z"/>
-<circle class="st2" cx="42.5" cy="44.9" r="12.7"/>
-<path class="st3" d="M43.5,46.1l12.5,0c0,7.5-4.8,12.4-12.5,12.4L43.5,46.1z"/>
+    <circle class="fal-quota-path__icon" cx="42.5" cy="44.9" r="12.7"/>
+    <path class="fal-quota-path__icon" d="M43.5,46.1l12.5,0c0,7.5-4.8,12.4-12.5,12.4L43.5,46.1z"/>
 </svg>


### PR DESCRIPTION
This prevents side effects on any icons using same default `.st` classes.

Resolves: #29