### PR TITLE
Update DDEV config for v1.22

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -8,24 +8,22 @@ router_https_port: "443"
 xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []
-mariadb_version: ""
-mysql_version: "5.7"
+database:
+    type: mysql
+    version: "5.7"
 hooks:
-  post-start:
-  - exec: composer install -d /var/www/html
-omit_containers: [dba]
+    post-start:
+        - exec: composer install -d /var/www/html
 use_dns_when_possible: true
 composer_version: "2"
 web_environment: []
-
-
-# This config.yaml was created with ddev version v1.17.7
-# webimage: drud/ddev-webserver:v1.17.7
-# dbimage: drud/ddev-dbserver-mariadb-10.3:v1.17.7
-# dbaimage: phpmyadmin:5
-# However we do not recommend explicitly wiring these images into the
-# config.yaml as they may break future versions of ddev.
-# You can update this config.yaml using 'ddev config'.
+nodejs_version: "18"
+upload_dirs:
+  [
+    "fileadmin",
+    "uploads",
+    "var"
+  ]
 
 # Key features of ddev's config.yaml:
 
@@ -36,24 +34,22 @@ web_environment: []
 
 # docroot: <relative_path> # Relative path to the directory containing index.php.
 
-# php_version: "7.4"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3", "7.4" "8.0"
+# php_version: "8.1"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2"
 
-# You can explicitly specify the webimage, dbimage, dbaimage lines but this
+# You can explicitly specify the webimage but this
 # is not recommended, as the images are often closely tied to ddev's' behavior,
 # so this can break upgrades.
 
 # webimage: <docker_image>  # nginx/php docker image.
-# dbimage: <docker_image>  # mariadb docker image.
-# dbaimage: <docker_image>
 
-# mariadb_version and mysql_version
-# ddev can use many versions of mariadb and mysql
-# However these directives are mutually exclusive
-# mariadb_version: 10.2
-# mysql_version: 8.0
+# database:
+#   type: <dbtype> # mysql, mariadb, postgres
+#   version: <version> # database version, like "10.4" or "8.0"
+#   mariadb versions can be 5.5-10.8 and 10.11, mysql versions can be 5.5-8.0
+#   postgres versions can be 9-15.
 
-# router_http_port: <port>  # Port to be used for http (defaults to port 80)
-# router_https_port: <port> # Port for https (defaults to 443)
+# router_http_port: <port>  # Port to be used for http (defaults to global configuration, usually 80)
+# router_https_port: <port> # Port for https (defaults to global configuration, usually 443)
 
 # xdebug_enabled: false  # Set to true to enable xdebug and "ddev start" or "ddev restart"
 # Note that for most people the commands
@@ -65,7 +61,7 @@ web_environment: []
 # "ddev xhprof" to enable xhprof and "ddev xhprof off" to disable it work better,
 # as leaving xhprof enabled all the time is a big performance hit.
 
-# webserver_type: nginx-fpm  # or apache-fpm
+# webserver_type: nginx-fpm, apache-fpm, or nginx-gunicorn
 
 # timezone: Europe/Berlin
 # This is the timezone used in the containers and by PHP;
@@ -73,12 +69,26 @@ web_environment: []
 # see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 # For example Europe/Dublin or MST7MDT
 
-# composer_version: ""
-# if composer_version:"" it will use the current ddev default composer release.
-# It can also be set to "1", to get most recent composer v1
-# or "2" for most recent composer v2.
-# It can be set to any existing specific composer version.
-# After first project 'ddev start' this will not be updated until it changes
+# composer_root: <relative_path>
+# Relative path to the composer root directory from the project root. This is
+# the directory which contains the composer.json and where all Composer related
+# commands are executed.
+
+# composer_version: "2"
+# You can set it to "" or "2" (default) for Composer v2 or "1" for Composer v1
+# to use the latest major version available at the time your container is built.
+# It is also possible to use each other Composer version channel. This includes:
+#   - 2.2 (latest Composer LTS version)
+#   - stable
+#   - preview
+#   - snapshot
+# Alternatively, an explicit Composer version may be specified, for example "2.2.18".
+# To reinstall Composer after the image was built, run "ddev debug refresh".
+
+# nodejs_version: "18"
+# change from the default system Node.js version to another supported version, like 14, 16, 18, 20.
+# Note that you can use 'ddev nvm' or nvm inside the web container to provide nearly any
+# Node.js version, including v6, etc.
 
 # additional_hostnames:
 #  - somename
@@ -92,8 +102,19 @@ web_environment: []
 # would provide http and https URLs for "example.com" and "sub1.example.com"
 # Please take care with this because it can cause great confusion.
 
-# upload_dir: custom/upload/dir
-# would set the destination path for ddev import-files to custom/upload/dir.
+# upload_dirs: "custom/upload/dir"
+#
+# upload_dirs:
+#   - custom/upload/dir
+#   - ../private
+#
+# would set the destination paths for ddev import-files to <docroot>/custom/upload/dir
+# When mutagen is enabled this path is bind-mounted so that all the files
+# in the upload_dirs don't have to be synced into mutagen.
+
+# disable_upload_dirs_warning: false
+# If true, turns off the normal warning that says
+# "You have Mutagen enabled and your 'php' project type doesn't have upload_dirs set"
 
 # working_dir:
 #   web: /var/www/html
@@ -102,15 +123,25 @@ web_environment: []
 # These values specify the destination directory for ddev ssh and the
 # directory in which commands passed into ddev exec are run.
 
-# omit_containers: [db, dba, ddev-ssh-agent]
+# omit_containers: [db, ddev-ssh-agent]
 # Currently only these containers are supported. Some containers can also be
 # omitted globally in the ~/.ddev/global_config.yaml. Note that if you omit
 # the "db" container, several standard features of ddev that access the
-# database container will be unusable.
+# database container will be unusable. In the global configuration it is also
+# possible to omit ddev-router, but not here.
 
-# nfs_mount_enabled: false
-# Great performance improvement but requires host configuration first.
-# See https://ddev.readthedocs.io/en/stable/users/performance/#using-nfs-to-mount-the-project-into-the-container
+# performance_mode: "global"
+# DDEV offers performance optimization strategies to improve the filesystem
+# performance depending on your host system. Should be configured globally.
+#
+# If set, will override the global config. Possible values are:
+#   - "global":  uses the value from the global config.
+#   - "none":    disables performance optimization for this project.
+#   - "mutagen": enables Mutagen for this project.
+#   - "nfs":     enables NFS for this project.
+#
+# See https://ddev.readthedocs.io/en/latest/users/install/performance/#nfs
+# See https://ddev.readthedocs.io/en/latest/users/install/performance/#mutagen
 
 # fail_on_hook_fail: False
 # Decide whether 'ddev start' should be interrupted by a failing hook
@@ -131,13 +162,13 @@ web_environment: []
 # The host port binding for the ddev-dbserver can be explicitly specified. It is dynamic
 # unless explicitly specified.
 
-# phpmyadmin_port: "8036"
-# phpmyadmin_https_port: "8037"
-# The PHPMyAdmin ports can be changed from the default 8036 and 8037
-
 # mailhog_port: "8025"
 # mailhog_https_port: "8026"
 # The MailHog ports can be changed from the default 8025 and 8026
+
+# host_mailhog_port: "8025"
+# The mailhog port is not normally bound on the host at all, instead being routed
+# through ddev-router, but it can be bound directly to localhost if specified here.
 
 # webimage_extra_packages: [php7.4-tidy, php-bcmath]
 # Extra Debian packages that are needed in the webimage can be added here
@@ -157,9 +188,9 @@ web_environment: []
 # If you prefer you can change this to "ddev.local" to preserve
 # pre-v1.9 behavior.
 
-# ngrok_args: --subdomain mysite --auth username:pass
+# ngrok_args: --basic-auth username:pass1234
 # Provide extra flags to the "ngrok http" command, see
-# https://ngrok.com/docs#http or run "ngrok http -h"
+# https://ngrok.com/docs/ngrok-agent/config or run "ngrok http -h"
 
 # disable_settings_management: false
 # If true, ddev will not create CMS-specific settings files like
@@ -177,10 +208,67 @@ web_environment: []
 # This is to enable experimentation with alternate file mounting strategies.
 # For advanced users only!
 
+# bind_all_interfaces: false
+# If true, host ports will be bound on all network interfaces,
+# not just the localhost interface. This means that ports
+# will be available on the local network if the host firewall
+# allows it.
+
+# default_container_timeout: 120
+# The default time that ddev waits for all containers to become ready can be increased from
+# the default 120. This helps in importing huge databases, for example.
+
+#web_extra_exposed_ports:
+#- name: nodejs
+#  container_port: 3000
+#  http_port: 2999
+#  https_port: 3000
+#- name: something
+#  container_port: 4000
+#  https_port: 4000
+#  http_port: 3999
+# Allows a set of extra ports to be exposed via ddev-router
+# Fill in all three fields even if you don’t intend to use the https_port!
+# If you don’t add https_port, then it defaults to 0 and ddev-router will fail to start.
+#
+# The port behavior on the ddev-webserver must be arranged separately, for example
+# using web_extra_daemons.
+# For example, with a web app on port 3000 inside the container, this config would
+# expose that web app on https://<project>.ddev.site:9999 and http://<project>.ddev.site:9998
+# web_extra_exposed_ports:
+#  - name: myapp
+#    container_port: 3000
+#    http_port: 9998
+#    https_port: 9999
+
+#web_extra_daemons:
+#- name: "http-1"
+#  command: "/var/www/html/node_modules/.bin/http-server -p 3000"
+#  directory: /var/www/html
+#- name: "http-2"
+#  command: "/var/www/html/node_modules/.bin/http-server /var/www/html/sub -p 3000"
+#  directory: /var/www/html
+
+# override_config: false
+# By default, config.*.yaml files are *merged* into the configuration
+# But this means that some things can't be overridden
+# For example, if you have 'nfs_mount_enabled: true'' you can't override it with a merge
+# and you can't erase existing hooks or all environment variables.
+# However, with "override_config: true" in a particular config.*.yaml file,
+# 'nfs_mount_enabled: false' can override the existing values, and
+# hooks:
+#   post-start: []
+# or
+# web_environment: []
+# or
+# additional_hostnames: []
+# can have their intended affect. 'override_config' affects only behavior of the
+# config.*.yaml file it exists in.
+
 # Many ddev commands can be extended to run tasks before or after the
 # ddev command is executed, for example "post-start", "post-import-db",
 # "pre-composer", "post-composer"
-# See https://ddev.readthedocs.io/en/stable/users/extending-commands/ for more
+# See https://ddev.readthedocs.io/en/stable/users/extend/custom-commands/ for more
 # information on the commands that can be extended and the tasks you can define
 # for them. Example:
 #hooks:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,11 @@
     "optimize-autoloader": true,
     "sort-packages": true,
     "vendor-dir": ".build/vendor",
-    "bin-dir": ".build/bin"
+    "bin-dir": ".build/bin",
+    "allow-plugins": {
+      "typo3/class-alias-loader": true,
+      "typo3/cms-composer-installers": true
+    }
   },
   "require": {
     "php": ">=7.2,<=7.4",


### PR DESCRIPTION
```
$> ddev mutagen st fal-quota -l

Mutagen: ok:
--------------------------------------------------------------------------------
Name: fal-quota
Identifier: sync_wP3BVmQSEIWKXAPQ9Eosp9I3Jw0QU0fUYhnrLW0sOxp
Labels:
	com.ddev.config-hash: f14e5d20a1b73978760be5180dc6817a2ee997df
	com.ddev.volume-signature: Users-<user>-docker-run-1691089960
Configuration:
	Synchronization mode: Two Way Resolved
	Hashing algorithm: Default (SHA-1)
	Maximum allowed entry count: Default (2⁶⁴−1)
	Maximum staging file size: Default (18 EB)
	Symbolic link mode: POSIX Raw
	Ignore VCS mode: Default (Propagate)
	Ignores:
		/.git
		/.tarballs
		/.ddev/db_snapshots
		/.ddev/.importdb*
		.DS_Store
		.idea
		/.build/web/fileadmin
		/.build/web/uploads
		/.build/web/var
	Permissions mode: Default (Portable)
Alpha:
	URL: <path>
	Configuration:
		Watch mode: Default (Portable)
		Watch polling interval: Default (10 seconds)
		Probe mode: Default (Probe)
		Scan mode: Default (Accelerated)
		Stage mode: Neighboring
		File mode: Default (0600)
		Directory mode: Default (0700)
		Default file/directory owner: Default
		Default file/directory group: Default
	Connected: Yes
	Synchronizable contents:
		1579 directories
		9872 files (149 MB)
		1 symbolic link
Beta:
	URL: docker://ddev-fal-quota-web/var/www/html
		DOCKER_HOST=unix://<path>.docker/run/docker.sock
	Configuration:
		Watch mode: Default (Portable)
		Watch polling interval: Default (10 seconds)
		Probe mode: Default (Probe)
		Scan mode: Default (Accelerated)
		Stage mode: Neighboring
		File mode: Default (0600)
		Directory mode: Default (0700)
		Default file/directory owner: Default
		Default file/directory group: Default
		Compression: Default (DEFLATE)
	Connected: Yes
	Synchronizable contents:
		1579 directories
		9872 files (149 MB)
		1 symbolic link
Status: Watching for changes
--------------------------------------------------------------------------------
```