### PR TITLE
Update TYPO3 to version 13.4

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
 name: fal-quota
 type: typo3
 docroot: .Build/public
-php_version: "8.3"
+php_version: "8.4"
 webserver_type: apache-fpm
 xdebug_enabled: false
 additional_hostnames: [ ]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+
       - uses: actions/checkout@v4
 
       - name: Validate composer.json

--- a/Classes/Controller/DashboardController.php
+++ b/Classes/Controller/DashboardController.php
@@ -52,7 +52,7 @@ class DashboardController extends ActionController
             'localizationFile',
             'LLL:EXT:fal_quota/Resources/Private/Language/locallang_mod.xlf'
         );
-        return $moduleTemplate->renderResponse();
+        return $moduleTemplate->renderResponse('Dashboard/Index');
     }
 
     protected function getBackendUser(): BackendUserAuthentication

--- a/Classes/Form/Element/MegaByteInputElement.php
+++ b/Classes/Form/Element/MegaByteInputElement.php
@@ -45,6 +45,7 @@ class MegaByteInputElement extends AbstractFormElement
         $attributes['class'] = implode(' ', $classes);
 
         $html = [];
+        $html[] = $this->renderLabel($fieldId);
         $html[] = '<div class="formengine-field-item t3js-formengine-field-item">';
         $html[] = $fieldInformationHtml;
         $html[] =   '<div class="form-wizards-wrap">';

--- a/Classes/Hooks/DatamapDataHandlerHook.php
+++ b/Classes/Hooks/DatamapDataHandlerHook.php
@@ -93,10 +93,9 @@ readonly class DatamapDataHandlerHook
             'sys_file_storage',
             $storageId,
             $storageId > 0 ? 2 : 1,
-            0,
+            null,
             1,
-            $message,
-            0
+            $message
         );
     }
 }

--- a/build/phpstan-baseline.neon
+++ b/build/phpstan-baseline.neon
@@ -1,0 +1,13 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Call to function method_exists\(\) with ''Networkteam\\\\SentryClient\\\\Client'' and ''captureMessage'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: ../Classes/Command/NotifyCommand.php
+
+		-
+			message: '#^Instanceof between TYPO3\\CMS\\Core\\Resource\\Folder and TYPO3\\CMS\\Core\\Resource\\Folder will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
+			count: 1
+			path: ../Classes/Handler/QuotaHandler.php

--- a/composer.json
+++ b/composer.json
@@ -29,35 +29,35 @@
     }
   },
   "require": {
-    "php": "^8.3",
+    "php": "^8.4",
     "psr/event-dispatcher": "^1.0",
     "psr/http-message": "^2.0",
     "psr/log": "^3.0",
     "symfony/console": "^7.3",
     "symfony/mime": "^7.3",
-    "typo3/cms-backend": "^12.4",
-    "typo3/cms-core": "^12.4",
-    "typo3/cms-extbase": "^12.4",
-    "typo3/cms-extensionmanager": "^12.4",
-    "typo3/cms-filelist": "^12.4",
-    "typo3/cms-fluid": "^12.4",
-    "typo3/cms-install": "^12.4",
-    "typo3/cms-scheduler": "^12.4",
-    "typo3fluid/fluid": "^2.15"
+    "typo3/cms-backend": "^13.4",
+    "typo3/cms-core": "^13.4",
+    "typo3/cms-extbase": "^13.4",
+    "typo3/cms-extensionmanager": "^13.4",
+    "typo3/cms-filelist": "^13.4",
+    "typo3/cms-fluid": "^13.4",
+    "typo3/cms-install": "^13.4",
+    "typo3/cms-scheduler": "^13.4",
+    "typo3fluid/fluid": "^4.2"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.75",
     "helmich/typo3-typoscript-lint": "^3.3",
     "networkteam/sentry-client": "^5.2",
     "phpstan/extension-installer": "^1.3",
-    "rector/rector": "^1.1",
+    "rector/rector": "^2.0",
     "roave/security-advisories": "dev-latest",
-    "saschaegerer/phpstan-typo3": "^1.10",
-    "ssch/typo3-rector": "^2.14",
-    "typo3/cms-beuser": "^12.4",
-    "typo3/cms-frontend": "^12.4",
-    "typo3/cms-lowlevel": "^12.4",
-    "typo3/cms-recordlist": "^12.4"
+    "saschaegerer/phpstan-typo3": "^2.0",
+    "ssch/typo3-rector": "^3.3",
+    "typo3/cms-beuser": "^13.4",
+    "typo3/cms-frontend": "^13.4",
+    "typo3/cms-lowlevel": "^13.4",
+    "typo3/cms-recordlist": "^13.4"
   },
   "suggest": {
     "ext-intl": "*"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -9,10 +9,10 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => 'typo3@mehrwert.de',
     'author_company' => 'mehrwert.de',
     'state' => 'stable',
-    'version' => '12.0.0',
+    'version' => '13.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '12.4.0-12.4.99',
+            'typo3' => '13.4.0-13.4.99',
         ],
         'conflicts' => [
         ],

--- a/rector.php
+++ b/rector.php
@@ -23,7 +23,7 @@ return RectorConfig::configure()
     ->withSets([
         Typo3SetList::CODE_QUALITY,
         Typo3SetList::GENERAL,
-        Typo3LevelSetList::UP_TO_TYPO3_12,
+        Typo3LevelSetList::UP_TO_TYPO3_13,
     ])
     ->withPHPStanConfigs([
         Typo3Option::PHPSTAN_FOR_RECTOR_PATH
@@ -33,8 +33,8 @@ return RectorConfig::configure()
     ])
     ->withPhpVersion(PhpVersion::PHP_83)
     ->withConfiguredRule(ExtEmConfRector::class, [
-        ExtEmConfRector::PHP_VERSION_CONSTRAINT => '8.3.0-8.3.99',
-        ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '12.4.0-12.4.99',
+        ExtEmConfRector::PHP_VERSION_CONSTRAINT => '8.4.0-8.4.99',
+        ExtEmConfRector::TYPO3_VERSION_CONSTRAINT => '13.4.0-13.4.99',
         ExtEmConfRector::ADDITIONAL_VALUES_TO_BE_REMOVED => []
     ])
     ->withSkip([


### PR DESCRIPTION
This pull request contains the necessary changes for compatibility with TYPO3 version 13.4.

This is a stacked PR to show how it differs from the branch for TYPO3 version 12.4.

Resolves: #42 